### PR TITLE
Added rootDir option to renderCalderaApp

### DIFF
--- a/src/server/index.tsx
+++ b/src/server/index.tsx
@@ -30,11 +30,11 @@ export type Dispatch = (
 
 export const renderCalderaApp = (
   app: React.ReactElement,
-  options: { port?: number; hostname?: string } = {}
+  options: { port?: number; hostname?: string; rootDir?: string; } = {}
 ) => {
   const savedStates = new Map<SessionID, Buffer>();
   const server = http.createServer((req, res) =>
-    serve(req, res, finalhandler(req, res))
+    serve(req, res, finalhandler(req, res), options)
   );
   const wss = new WebSocket.Server({
     noServer: true,

--- a/src/server/serve.ts
+++ b/src/server/serve.ts
@@ -2,13 +2,16 @@ import { IncomingMessage, ServerResponse } from "http";
 import path from "path";
 import fs from "fs";
 
-const rootDir = path.resolve(__dirname, "..", "public");
+const calderaRootDir = path.resolve(__dirname, "..", "public");
 
 const serve = (
   req: IncomingMessage,
   res: ServerResponse,
-  onError: (err: any) => void
+  onError: (err: any) => void,
+  options: { rootDir?: string; } = {}
 ) => {
+  let rootDir = (options.rootDir ? options.rootDir : calderaRootDir);
+
   const url = req.url;
 
   let filePath = "index.html";
@@ -16,6 +19,7 @@ const serve = (
 
   if (url === "/caldera-client.js") {
     filePath = url.slice(1);
+    rootDir = calderaRootDir;
     mimeType = "application/javascript";
   }
 


### PR DESCRIPTION
Thanks for creating a great framework with Caldera!

I wanted to be able to customize the public/index.html template to get things setup properly before the Head tag takes over. This ensures a really great user experience where nothing flashes and CSS can be pre-loaded to handle loading gracefully.

This commit creates a new option on the `renderCalederaApp` function allowing users to set their own public directory. This allows customization of the template, CSS, scripts, etc...

This change keeps the caledera-client.js being served from the Caledera root directory.

Please let me know if anything needs to be changed, I think this would be a great addition to Caldera. Thanks!